### PR TITLE
updated to net10 in csproj

### DIFF
--- a/LinqExercise/LinqExercise.csproj
+++ b/LinqExercise/LinqExercise.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the target framework of the `LinqExercise` project to use the latest .NET version.

Project configuration:

* Updated the `TargetFramework` in `LinqExercise.csproj` from `net9.0` to `net10.0`, ensuring compatibility with the newest .NET features and improvements.